### PR TITLE
Update .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
-PAGE_ICON = "images/kingvisher_128.png"
-PAGE_IMAGE = "images/kingvisher_512.png"
-GITHUB_REPO = "https://github.com/WSE-research/KinGVisher-Knowledge-Graph-Visualizer"
-DESCRIPTION = "\nFor more details, see our [GitHub repository](%s) where you can also [submit bug reports](%s) and [feature requests](%s)."
-META_DESCRIPTION = "A tool for visualizing knowledge graph data from SPARQL endpoints. It provides a user-friendly interface for exploring the data and creating visualizations by defining resources that are used as starting points for graph exploration, white and black lists for predicates, and visual styles for the nodes and edges." 
-REPLACE_INDEX_HTML_CONTENT = True
-CANONICAL_URL = https://wse-research.org/KinGVisher-Knowledge-Graph-Visualizer/
+PAGE_ICON="images/kingvisher_128.png"
+PAGE_IMAGE="images/kingvisher_512.png"
+GITHUB_REPO="https://github.com/WSE-research/KinGVisher-Knowledge-Graph-Visualizer"
+DESCRIPTION="\nFor more details, see our [GitHub repository](%s) where you can also [submit bug reports](%s) and [feature requests](%s)."
+META_DESCRIPTION="A tool for visualizing knowledge graph data from SPARQL endpoints. It provides a user-friendly interface for exploring the data and creating visualizations by defining resources that are used as starting points for graph exploration, white and black lists for predicates, and visual styles for the nodes and edges." 
+REPLACE_INDEX_HTML_CONTENT=True
+CANONICAL_URL=https://wse-research.org/KinGVisher-Knowledge-Graph-Visualizer/


### PR DESCRIPTION
" = " doesn't work on osx:

```
.env:1: command not found: PAGE_ICON
.env:2: command not found: PAGE_IMAGE
.env:3: command not found: GITHUB_REPO
.env:4: command not found: DESCRIPTION
.env:5: command not found: META_DESCRIPTION
.env:6: command not found: REPLACE_INDEX_HTML_CONTENT
.env:7: command not found: CANONICAL_URL
```